### PR TITLE
Fixes issue of pyquil-for-azure-quantum not working with new releases of azure-quantum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyquil-for-azure-quantum"
-version = "0.0.2"
+version = "0.0.3"
 description = "Run Quil programs on Microsoft Azure Quantum using pyQuil"
 authors = ["Dylan Anthony <danthony@rigetti.com>"]
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
 pyquil = { version = "^3.1.0", allow-prereleases = true }
-azure-quantum = "^0.25.218240"
+azure-quantum = ">=0.27,<1.0"
 lazy-object-proxy = "^1.7.1"
 wrapt = "^1.14.0"
 numpy = "^1.21.6"


### PR DESCRIPTION
# Problem
The current `0.0.2` release of `pyquil-for-azure-quantum` does not work with new releases of the `azure-quantum` package because the current dependency constraint `^0.25.218240` effectively becomes `<0.26.0,>=0.25.218240` and every month Microsoft creates a new release of `azure-quantum` that increments the minor version.

When doing a `pip install` for both latest releases of `pyquil-for-azure-quantum` and `azure-quantum`, PIP returns this error:
> pyquil-for-azure-quantum 0.0.2 requires azure-quantum<0.26.0,>=0.25.218240, but you have azure-quantum 0.27.258449 which is incompatible.

# Fix
This PR relaxes the dependency constraint of `azure-quantum` to be `>=0.27,<1.0`.

It also increments the version of `pyquil-for-azure-quantum` to `0.0.3` expecting that a new package will be released with the updated dependency constraint.